### PR TITLE
Build arm64 binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,7 +53,7 @@ changelog:
 
 release:
   github:
-    owner: Hello-User
+    owner: ebarped
     name: kubeswap
   footer: >-
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     ldflags:
       - -s -w -X github.com/ebarped/kubeswap/cmd.Version={{.Version}}
 
@@ -52,7 +53,7 @@ changelog:
 
 release:
   github:
-    owner: ebarped
+    owner: Hello-User
     name: kubeswap
   footer: >-
 


### PR DESCRIPTION
Simple added a build target. This is required for MacOS 27 compatibility as they've dropped support for x86 applications. I've done some testing and the arm64 binary, cross-compiled on my x86 machine, works fine on my Mac. I have not tested the Windows and Linux arm64 builds but I expect them to work without issues.